### PR TITLE
Add outputs for EC2 instance info

### DIFF
--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,7 @@
+output "instance_public_ip" {
+  value = aws_instance.web.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.web.id
+}


### PR DESCRIPTION
## Summary
- expose EC2 instance details via outputs

## Testing
- `terraform fmt -check && terraform validate` *(fails: `terraform` not found)*