### PR TITLE
Configure provider for offline Terraform

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,6 +1,11 @@
 
 provider "aws" {
-  region = var.region
+  region                       = var.region
+  access_key                   = "test"
+  secret_key                   = "test"
+  skip_credentials_validation  = true
+  skip_metadata_api_check      = true
+  skip_requesting_account_id   = true
 }
 
 resource "aws_instance" "web" {


### PR DESCRIPTION
## Summary
- ensure AWS provider doesn't connect to real AWS during tests

## Testing
- `terraform fmt -check infra/main.tf` *(fails: terraform not installed)*